### PR TITLE
Add Jupyter Notebook tutorial and binder integration

### DIFF
--- a/JupyterNotebookForGreatGood/.gitignore
+++ b/JupyterNotebookForGreatGood/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints/
+None0000000.png

--- a/JupyterNotebookForGreatGood/00 - basics of Jupyter.ipynb
+++ b/JupyterNotebookForGreatGood/00 - basics of Jupyter.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A Code Cell. Execute by clicking it, then Cell > Run Cells in the toolbar or pressing Esc, then Ctrl+Enter\n",
+    "# you'll know it executed if the phrase below appears underneath it.\n",
+    "print(\"welcome to jupyter!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A Markdown Cell\n",
+    "\n",
+    "Markdown cells contain text formatted by the markdown engine.\n",
+    "\n",
+    "For a full guide, check out [this link](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).\n",
+    "\n",
+    "If you ever see something cool in somebody else's Jupyter Notebook, just double click the cell and you'll be able to see how it was done. Try on this cell now. To return a markdown cell to its formatted style, \"execute\" it by pressing `Esc` then `Ctrl+Enter` while your text cursor is in the cell.\n",
+    "\n",
+    "You can style text: *italic*, **bold**, ***italic plus bold***, ~~strikethrough~~, `fixed width`.\n",
+    "\n",
+    "You can make lists and sublists, ordered or unordered:\n",
+    "\n",
+    "1. first things first i'll eat your brains\n",
+    "1. then imma start rocking\n",
+    "  * gold teeth\n",
+    "  * chains\n",
+    "\n",
+    "You can include quotes:\n",
+    "\n",
+    "> The problem with internet quotes is that you can't always depend on their accuracy.\n",
+    "> <br> Abraham Lincoln, *State of the Union, 1864*\n",
+    "\n",
+    "You can write mathematics using LaTeX, aka $\\LaTeX$, like so: $$\\log p\\left(\\vec{x}\\right) = \\vec{x}^\\top \\Sigma^{-1} \\vec{x} - \\log Z\\left(\\Sigma\\right)$$.\n",
+    "\n",
+    "You can even include blocks of code, with syntax highlighting\n",
+    "\n",
+    "```python\n",
+    "def factorial(x):\n",
+    "    if x in [0, 1]:\n",
+    "        return 1\n",
+    "    else:\n",
+    "        return x * factorial(x-1)\n",
+    "```\n",
+    "\n",
+    "As an alternative to markdown formatting, you can also use HTML+CSS, like\n",
+    "<span style=\"color:#1874CD; font-style: oblique; font-weight: bold;\">so</span>.\n",
+    "\n",
+    "The two do not always mix, however."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the Jupyter Notebok\n",
+    "\n",
+    "When using the Jupyter notebook, you switch between Command Mode, in which you use keystrokes to do things like execute, add, or delete cells, and Edit Mode, in which keystrokes change the contents of the cells.\n",
+    "\n",
+    "You enter Edit Mode by clicking an un-rendered Markdown cell or a code cell. Note that this means you need to triple-click to start editing a rendered Markdown cell.\n",
+    "\n",
+    "You enter Command Mode by pressing `Esc`. That is why the \"execute cells\" shortcut in the previous two cells was prefixed with an `Esc`. To see the full list of commands, press `H` while in Command Mode. This will also show you the (system-specific) keyboard shortcuts for Edit Mode. If you remember only one keyboard command in Jupyter, make it `Esc, H`.\n",
+    "\n",
+    "If you remember more than one, remember \"restart the kernel\", or `Esc, 00`, which kills the underlying kernel of the notebook and starts a new one. Note that this means all of your computed values will disappear!\n",
+    "\n",
+    "When you're done with a Jupyter notebook, close it and shut off the kernel by clicking, in the toolbar, `File > Close and Halt`. If you just want to close the tab, but preserve all the values you've computed, just close the tab. You'll be able to reopen the notebook from the file browser. Note that shutting off the kernel won't delete anything that's in the outputs (e.g. the printed `welcome to jupyter!` above). We'll talk about this more in `01`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/JupyterNotebookForGreatGood/01 - Jupyter for python programming and data science.ipynb
+++ b/JupyterNotebookForGreatGood/01 - Jupyter for python programming and data science.ipynb
@@ -475,7 +475,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are lots of options for plot aesthetics available. One of my favorites, based on the style of plots in the XKCD webcomic, is set by the cell below."
+    "There are lots of options for plot aesthetics available. One of my favorites, based on the style of plots in the XKCD webcomic, is set by the cell below. It doesn't work super well with seaborn, so try it on the pure matplotlib plot a few cells back."
    ]
   },
   {

--- a/JupyterNotebookForGreatGood/01 - Jupyter for python programming and data science.ipynb
+++ b/JupyterNotebookForGreatGood/01 - Jupyter for python programming and data science.ipynb
@@ -1,0 +1,512 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Python Programming and Data Science in Jupyter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constructing and Viewing the Environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a notebook, we can interactively build up an environment of functions, variables, objects, and so on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remember that we execute cells by pressing `Ctrl+Enter` in Command Mode. If you'd like to execute the currently selected cell and then highlight the next one, press `Shift+Enter`. Pressing this repeatedly is the fastest way to execute a chunk of code blocks in a line. And don't worry, executing a rendered Markdown cell doesn't hurt it, so you can just steamroll past them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lst = [\"one\", 2, \"III\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to see what the current value of a variable is, we can either print it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(lst)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or we make it the output of the last line of code in the cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lst"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def foo():\n",
+    "    return lst\n",
+    "\n",
+    "foo()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But then why didn't anything show up when we ran `print(lst)`? If the return value of the last line is `None`, nothing is displayed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And BTW, there's nothing to stop us from doing both!\n",
+    "\n",
+    "We get to see *two* outputs from our code cells: one is the `st`an`d`ard `out`, or `stdout`, which is where `print` puts things, and the other is the cell output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(lst)\n",
+    "lst"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The environment is shared and interactive, so I can do something like the cell below, then run any of the cells above and get a new output, with `fore` at the end of the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lst.append(\"fore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I could even put that cell all the way at the top, before the definition of `lst`, and it would still run.\n",
+    "\n",
+    "Beware though! When you shut down a Jupyter kernel, the environment disappears. If you aren't careful, getting the notebook back into the state it was in when you shut down can be very difficult. It's considered best practices to build the environment *linearly*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BTW, Python has lots of neat tools for inspecting objects in the environment, and Jupyter has special support for some of them.\n",
+    "\n",
+    "The built-in function `dir` returns a list of all of the attributes of an object (everything that can be accessed by `foo.something`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir(lst)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If an attribute starts with a single `_`, that's a sign that you shouldn't care about it. If it starts with two `_`s, that means it's a special method that gets called by an operator or other special entity (i.e., not you), like `+` and `__add__`.\n",
+    "\n",
+    "So let's make a more succinct dir:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def shortdir(obj):\n",
+    "    \"\"\"Same as built-in dir, but removes all items beginning with _\n",
+    "    from the returned list.\n",
+    "    \"\"\"\n",
+    "    return [item for item in dir(obj) if not item.startswith(\"_\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortdir(lst)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is useful for examining objects, but not functions or methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortdir(shortdir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Something that's more useful for examining functions and methods is the `?` operator, which creates a tiny window at the bottom of your screen containing additional information.\n",
+    "\n",
+    "More useful is `??` which prints more verbosely. For functions, this includes the actual Python code that defined the function, which can be very useful when you forget the call signature or defaults of a function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortdir?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortdir??"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Even faster then using any of these methods is the Jupyter tooltip. Pressing `Shift+Tab` while your text cursor is at the end of a word in Edit Mode will bring up the same information as `?`, but without having to execute the cell. Even more handy for quickly reminding yourself of how a function works!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shortdir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just to emphasize: there's nothing magic here. Our homemade `shortdir` hooked into this system just fine. The one trick we needed to know was how to write a doc-string in Python, which is something we should be doing as often as possible!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting in Jupyter with Matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's one tiny trick to get `matplotlib` working in Jupyter: you need the following line, called a `magic`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tells Jupyter how to handle the display of `matplotlib` plots. We'll see an alternative to `inline` later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.arange(-3, 3, 0.01)\n",
+    "plt.plot(xs, np.exp(-np.square(xs)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that we have this ugly `[<matplotlib.lines.Line2D at 0x ...]` above our plot, next to the `Out[n]`. Can you explain why that happens?\n",
+    "\n",
+    "We can fix it by adding a semi-colon to the end of the line."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pandas in Jupyter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need a dataset to get started. We'll use the [Iris dataset](https://en.wikipedia.org/wiki/Iris_flower_data_set) that inspired the GDSO logo. This dataset contains information about the petals and sepals (leaves underneath the petals) for three species of the *Iris* genus of flower.\n",
+    "\n",
+    "The dataset is available [at this link](https://raw.githubusercontent.com/pandas-dev/pandas/master/pandas/tests/data/iris.csv) if you'd like to download it by hand, otherwise, run the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.name is \"posix\":\n",
+    "    !curl \"https://raw.githubusercontent.com/pandas-dev/pandas/master/pandas/tests/data/iris.csv\" -o res/data/iris.csv\n",
+    "else:\n",
+    "    !certutil.exe -urlcache -split -f \"https://raw.githubusercontent.com/pandas-dev/pandas/master/pandas/tests/data/iris.csv\" res/data/iris.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Side note on shell commands"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lines in the above cell that start with `!` execute in the command line. Executing command line utilities can be incredibly useful -- you can even perform your environment installations inside Jupyter!\n",
+    "\n",
+    "Even better, the execution of these tools can be controlled in Python. Above, I used an `if` statement to check whether the OS was of the `posix` family, which includes OS X and Linux, which determined the utility I used to download information from the web."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Returning to our dataset: we can load the data into `pandas` and display the first five rows with `.head()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame.from_csv(\"res/data/iris.csv\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are using a recent version of Jupyter, then this dataframe should be printed with some nice formatting: color behind alternate rows, and highlighting on hover. This is one of the benefits of Jupyter's all-HTML format -- outputs are (usually) in HTML, so all the power of CSS and even JavaScript can be used to prettify them and make them more useful.\n",
+    "\n",
+    "When presenting this material, this is where I stop and show folks how the dataframe head above and the matplotlib plot image are stored in the `.ipynb` file. The image is about 450 lines down, and the table 100 lines further. You should check out the files for yourself using a simple text editor (vim, emacs, nano, sublime, textedit, or notepad) to confirm."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pandas is a powerful library for data science in Python, and you should learn it if you get the chance! I recommend [Brandon Rhodes' PyCon 2015 Tutorial](https://github.com/brandon-rhodes/pycon-pandas-tutorial), which is also an additional introduction to Jupyter notebooks.\n",
+    "\n",
+    "For now, we'll just use `.describe` to get some descriptive statistics on our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting in Jupyter with Seaborn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a heads up, I strongly recommend that you check out the [seaborn data visualization library](https://seaborn.pydata.org/). Seaborn is a platform built on top of matplotlib in order to make data visualization a lot easier, as it is in `R` with `ggplot`. See below for examples of just how much easier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(df);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.pairplot(df, hue=\"Name\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another tip: some folks find the matplotlib styling \"ugly\" (though it improved a lot in version 2.0), so try running the cell below, which changes the plotting aesthetics to a default designed by the seaborn folks, and then running those above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.set()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are lots of options for plot aesthetics available. One of my favorites, based on the style of plots in the XKCD webcomic, is set by the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.xkcd();"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/JupyterNotebookForGreatGood/01 - Jupyter for python programming and data science.ipynb
+++ b/JupyterNotebookForGreatGood/01 - Jupyter for python programming and data science.ipynb
@@ -165,7 +165,7 @@
    "source": [
     "If an attribute starts with a single `_`, that's a sign that you shouldn't care about it. If it starts with two `_`s, that means it's a special method that gets called by an operator or other special entity (i.e., not you), like `+` and `__add__`.\n",
     "\n",
-    "So let's make a more succinct dir:"
+    "So let's make a more succinct `dir`:"
    ]
   },
   {
@@ -383,7 +383,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame.from_csv(\"res/data/iris.csv\")\n",
+    "df = pd.read_csv(\"res/data/iris.csv\")\n",
     "df.head()"
    ]
   },

--- a/JupyterNotebookForGreatGood/02 - multimedia and HTML using IPython.display.ipynb
+++ b/JupyterNotebookForGreatGood/02 - multimedia and HTML using IPython.display.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `IPython.display`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `display` submodule of `IPython`, the Python kernel that is typically used with Jupyter, has the ability to handle a pretty absurd variety of content modalities through the common language of HTML+JS. The cell below will import this module and return a list of its submodules, each of which corresponds to a different modality.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NOTE: many of these methods either take a locally-hosted file or a url to a remotely-hosted file. They work equally well in both cases. In order to keep the GitHub repo for this tutorial small, I am sticking to the remote strategy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython import display\n",
+    "\n",
+    "dir(display)[:23]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `display.Audio`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Starting small: we can \"display\" an audio file, making it playable.\n",
+    "\n",
+    "The file can be an array, which we generate ourselves, as in the example below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lngth = 5; base_freq = 220; rate = 44100\n",
+    "ts = np.arange(0, lngth, step=lngth/2/rate)\n",
+    "sweep = np.sqrt((lngth-ts)) * (np.sin(base_freq*ts**2) + np.sin(base_freq*np.power(2, 5/12)*ts**2))\n",
+    "\n",
+    "display.Audio(sweep, rate=rate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or it could be a music file, either stored locally or hosted remotely:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "display.Audio(url=\"https://www.myinstants.com/media/sounds/expedientes-secretos-x-musica22.mp3\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `display.Image`\n",
+    "\n",
+    "Markdown can already display images, so why is `display.Image` useful? Because it can do gifs, either local or remote!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "display.Image(url=\"https://media2.giphy.com/media/l49K1AIQuatbvL4LS/giphy.gif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `display.HTML`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Animations and Videos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just recently, the folks at matplotlib started to get on the HTML and JavaScript train, and they now provide a simple way to export their animated figures as JS/HTML. That means that Jupyter's HTML method can be used to display them.\n",
+    "\n",
+    "For this example, I am indebted to [Louis Tiao's blogpost](http://tiao.io/posts/notebooks/embedding-matplotlib-animations-in-jupyter-as-interactive-javascript-widgets/). If you want to learn more about embedding matplotlib animations, check out their blog!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.animation as anim"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that we no longer need the `%matplotlib` magic anymore. We're handling plot display ourselves now!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def init_video(x_eps=0.01, t_eps=0.1, temp_init=0.1):\n",
+    "    \"\"\"prepare all the components of the Gaussian animation\n",
+    "    \"\"\"\n",
+    "    fig, ax = plt.subplots()\n",
+    "    xmin = -3; xmax = 3\n",
+    "    \n",
+    "    ax.set_xlim((xmin, xmax))\n",
+    "    ax.set_ylim((0, 1.25))\n",
+    "\n",
+    "    line, = ax.plot([], [], lw=3)\n",
+    "    \n",
+    "    def init_frame(): \n",
+    "        \"\"\"clear the line data before each frame\"\"\"\n",
+    "        line.set_data([], [])\n",
+    "        return (line,)\n",
+    "    \n",
+    "    xs = np.arange(xmin, xmax, x_eps)\n",
+    "    def animate(i):\n",
+    "        ys = np.exp(-xs**2/(t_eps*i+temp_init))\n",
+    "        line.set_data(xs, ys)\n",
+    "        return (line,)\n",
+    "    \n",
+    "    plt.close()\n",
+    "    \n",
+    "    return fig, animate, init_frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The code cell above defines a function that sets up a short animation of a Gaussian distribution increasing in width. The cell below runs that function and uses it to produce an animation, which it then displays by means of `display.HTML` and the `to_jshtml` method, which turns the animation into an interactive JS widget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "fig, animate, init_frame = init_video(t_eps=0.01)\n",
+    "\n",
+    "framerate = 60; length = 2\n",
+    "num_frames = framerate*length\n",
+    "animation = anim.FuncAnimation(fig, animate, init_func=init_frame,\n",
+    "                                frames=num_frames, interval=1000/60)\n",
+    "\n",
+    "display.HTML(animation.to_jshtml())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you have `ffmpeg` installed in a place where Python can find it, then you can produce a video version of the animation, suitable for saving to a `.mp4` file, by means of the `.to_html5_video` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# display.HTML(animation.to_html5_video())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Aribtrary HTML websites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Anything that's pure HTML can be displayed by this method. That includes the lion's share of a lot of websites!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display.HTML(url=\"https://google.com\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `display.IFrame`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`i`nline `frame`s, or `iframe`s, are used to display content from one website inside another. They used to be popular to, e.g., display quiz results on personal blogs, customize MySpace pages, and other very early 00s stuff. Despite the retro vibe, there are still some valid reasons to use `iframe`s to display content from another webpage. `iframe`s can also be used to connect Jupyter notebooks to external websites, to, e.g., poll a room full of notebook users and display the results in real time. The example below uses the `iframe` capability of Google Maps to display a map of the UC Berkeley campus. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src = \"http://bit.ly/my_iframe\"\n",
+    "display.IFrame(src=src,\n",
+    "               width=\"600\", height=\"450\", frameborder=\"0\", style=\"border:0\", allowfullscreen=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `display.YouTubeVideo`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`display.IFrame` could be used to display a video, but displaying videos is probably one of the most obvious uses for `iframe`s, so there are some more convenient interfaces. `display.YouTubeVideo` requires only the video identifier as a string. `display.Video` can be used with other video sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display.YouTubeVideo(\"b3_lVSrPB6w\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/JupyterNotebookForGreatGood/03 - interactive JS with ipywidgets.ipynb
+++ b/JupyterNotebookForGreatGood/03 - interactive JS with ipywidgets.ipynb
@@ -1,0 +1,302 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `ipywidgets`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the `ipywidgets` module, an add-on to Jupyter, you can create interactive Python functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Widget Basics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The simplest interface is the function `ipywidgets.interact`, which, in its simplest form, takes a function and makes a widget that lets you change the values of its arguments. Each time an argument is changed, the function is called again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lst = [\"hello\", \"it's me\", \"i was wondering\", \"if after all these years you'd like to meet\"]\n",
+    "\n",
+    "def my_function(the_box_is_checked=False, integer=(0, 2), string=lst):\n",
+    "    pass\n",
+    "\n",
+    "ipywidgets.interact(my_function);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The type of widget is inferred from the type of the argument. So, because `this_box_is_checked` is a boolean (`True`/`False`), the widget is a checkbox, because `integer` is a tuple, the widget is a slider, and because `string` is a list, the widget is a dropdown menu."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above example is obviously useless -- `my_function` does nothing with its arguments. Generally, if we want the interaction to do something that the user can see, we need to either `print` or `plot` something.\n",
+    "\n",
+    "The example below is a reasonably minimal example of such an interaction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_function(this_box_is_checked=False, integer=(0, 2), string=lst):\n",
+    "    if this_box_is_checked:\n",
+    "        print(integer*string)\n",
+    "\n",
+    "ipywidgets.interact(my_function);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Widgets for Interactive Plotting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One of the most common uses is for interactive plotting. In that case, we need to use, instead of the typical `%matplotlib inline` magic, the `%matplotlib notebook` magic to get interactive plots. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The examples below show how to create a variety of interactive plots.\n",
+    "\n",
+    "In general, you  set up the plot, then draw something on it that you want the user to interact with. Then you create a function that, when it is called, changes the values of the thing you drew."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### A Line with Interactive Slope"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the example below, we draw a `line` on an `ax`is using `ax.plot`. The function that modifies it is `f` and it changes the slope of the line using `line.set_data`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def setup_plot_cartesian(mn, mx):\n",
+    "    \"\"\"create a figure and axes with the origin in the center\n",
+    "    and the Cartesian x- and y-axes (y=0 and x=0) drawn in.\n",
+    "    \"\"\"\n",
+    "    fig, ax = plt.subplots()\n",
+    "    ax.set_xlim([mn, mx]); ax.set_ylim([mn, mx])\n",
+    "    plt.hlines(0, 2*mn, 2*mx)\n",
+    "    plt.vlines(0, 2*mn, 2*mx)\n",
+    "    \n",
+    "    return fig, ax\n",
+    "\n",
+    "def make_line_plotter():\n",
+    "    \"\"\"create a function that plots a line with variable slope parameter,\n",
+    "    suitable for use with ipywidgets.interact.\n",
+    "    \"\"\"\n",
+    "    fig, ax = setup_plot_cartesian(-1, 1)\n",
+    "    \n",
+    "    xs = np.arange(-2, 2, 1)\n",
+    "    line, = ax.plot(xs, xs)\n",
+    "    \n",
+    "    plt.axis(\"off\")\n",
+    "    \n",
+    "    def f(m=0.):\n",
+    "        line.set_data(xs, m*xs)\n",
+    "    \n",
+    "    return f\n",
+    "\n",
+    "f = make_line_plotter()\n",
+    "ipywidgets.interact(f, m=ipywidgets.FloatSlider(0, min=-10, max=10));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### A Line with Interactive Slope and Color"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We're not stuck just modifying the data of a plot. There are a variety of `.set_foo` methods that let us set a property `foo` of a plot.\n",
+    "\n",
+    "The example below also sets the color. Notice that we just had to add a line calling the `.set_color` method to our previous example.\n",
+    "\n",
+    "As an added bonus, we pull our colors from the [XKCD color survey](https://blog.xkcd.com/2010/05/03/color-survey-results/), which has been added to matplotlib. These colors are often more visually appealing than the base matplotlib colors, and they have very memorable names!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_colorful_line_plotter():\n",
+    "    \"\"\"create a function that plots a line with variable slope parameter,\n",
+    "    and a variable color, suitable for use with ipywidgets.interact.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    fig, ax = setup_plot_cartesian(-1, 1)\n",
+    "    xs = np.arange(-2, 2, 1)\n",
+    "    line, = ax.plot(xs, xs, lw=2)\n",
+    "    \n",
+    "    plt.axis(\"off\")\n",
+    "    \n",
+    "    def f(m=0., color=\"cloudy blue\"):\n",
+    "        line.set_data(xs, m*xs)\n",
+    "        line.set_color(\"xkcd:\"+color)\n",
+    "    \n",
+    "    return f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color_options = [color_key.split(\":\")[1] for color_key in matplotlib.colors.XKCD_COLORS.keys()]\n",
+    "\n",
+    "f = make_colorful_line_plotter()\n",
+    "ipywidgets.interact(f, m=ipywidgets.FloatSlider(0, min=-10, max=10),\n",
+    "                   color=ipywidgets.Dropdown(options=color_options));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Bespoke Data Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now on to a moderately more useful and data-science-y example.\n",
+    "\n",
+    "Normally, we fit our data using maximum likelihood. If we're fitting a Gaussian to our data, that means calculating the mean and standard deviation/variance of the data (or, from another perspective, every time we report our data as a mean ± standard deviation, we're fitting a Gaussian to our data).\n",
+    "\n",
+    "Alternatively, we could fit our data by hand! The cell below generates an interactive plot with a histogram of the data and a freely modifiable Gaussian probability curve. You can use the sliders to adjust the center and spread of the curve until it seems to fit the data nicely, and then compare it with the `true` mean `mu` and variance `Sigma`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "def make_gauss_fitter(data, true_mu, true_Sigma):\n",
+    "    \"\"\"given a dataset with a given mean mu and variance Sigma,\n",
+    "    construct a function that plots a gaussian pdf with variable\n",
+    "    mean and variance over a normed histogram of the data.\n",
+    "    intended for use with ipywidgets.interact.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    xs = np.arange(-5*np.sqrt(true_Sigma)+true_mu,\n",
+    "                   5*np.sqrt(true_Sigma)+true_mu,\n",
+    "                   0.01)\n",
+    "    gauss_pdf = lambda xs, mu, sigma: (1/np.sqrt(2*np.pi*sigma))*np.exp((-0.5*(xs-mu)**2)/sigma)\n",
+    "    \n",
+    "    fig, ax = plt.subplots()\n",
+    "    hist = ax.hist(data, normed=True, bins=max(10, N//50))\n",
+    "    fit, = plt.plot(xs, gauss_pdf(xs, 0, 1), lw=4) \n",
+    "    \n",
+    "    def f(mu=0., sigma=1.):\n",
+    "        fit.set_data(xs, gauss_pdf(xs, mu, sigma))\n",
+    "    \n",
+    "    return f\n",
+    "\n",
+    "true_mu = 2.; true_Sigma = 0.5; N = 20;\n",
+    "data = np.sqrt(true_Sigma)*np.random.standard_normal(size=N) + true_mu\n",
+    "\n",
+    "\n",
+    "f = make_gauss_fitter(data, true_mu, true_Sigma)\n",
+    "ipywidgets.interact(f, mu=ipywidgets.FloatSlider(0, min=-10, max=10),\n",
+    "                   sigma=ipywidgets.FloatSlider(1., min=1e-1, max=10, step=1e-1));"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/JupyterNotebookForGreatGood/03 - interactive JS with ipywidgets.ipynb
+++ b/JupyterNotebookForGreatGood/03 - interactive JS with ipywidgets.ipynb
@@ -260,7 +260,7 @@
     "    gauss_pdf = lambda xs, mu, sigma: (1/np.sqrt(2*np.pi*sigma))*np.exp((-0.5*(xs-mu)**2)/sigma)\n",
     "    \n",
     "    fig, ax = plt.subplots()\n",
-    "    hist = ax.hist(data, normed=True, bins=max(10, N//50))\n",
+    "    hist = ax.hist(data, density=True, bins=max(10, N//50))\n",
     "    fit, = plt.plot(xs, gauss_pdf(xs, 0, 1), lw=4) \n",
     "    \n",
     "    def f(mu=0., sigma=1.):\n",

--- a/JupyterNotebookForGreatGood/README.md
+++ b/JupyterNotebookForGreatGood/README.md
@@ -1,0 +1,31 @@
+# How to Use this Tutorial
+
+## Method 1: Binder
+
+[binder](http://mybinder.org) is a free service that creates temporary cloud-deployed computational environments from GitHub repos.
+Click the badge below (and wait up to a few minutes) to create one for this repository.
+You'll be dropped into a new tab in your browser.
+Open the `JupyterNotebookForGreatGood` folder and then `00 - basics of Jupyter.ipynb` to get started.
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/charlesfrye/DSW2018-tutorials/master)
+
+## Method 2: Local Installation
+
+If you have the [Anaconda distribution](https://conda.io/miniconda.html)
+of Python installed, download/clone this repository and then
+navigate into the folder and run the command
+```
+conda env create -f environment.yml
+```
+in the Terminal/Command Prompt.
+
+If you'd like to use `pip`+`virtualenv`, check the `environment.yml` file for dependencies.
+The dependency on `rise` can be safely omitted if you're not trying to run `presentation.ipynb` as a presentation.
+
+Once installation is complete, activate the environment
+(Anaconda will provide instructions in the Terminal/Prompt)
+and then run
+```
+jupyter notebook
+```
+in the Terminal/Prompt.

--- a/JupyterNotebookForGreatGood/presentation.ipynb
+++ b/JupyterNotebookForGreatGood/presentation.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "If you'd like to follow along, either\n",
     "\n",
-    "1) head to the GitHub repo for this talk, http://bit.ly/DSW2018-jpnbfgg-github, and follow the installation instructions\n",
+    "1) head to the GitHub repo for the DSW, http://bit.ly/DSW2018-jpnbfgg-github, and follow the installation instructions in the `JupyterNotebookForGreatGood` folder\n",
     "\n",
     "2) go to this link http://bit.ly/DSW2018-jpnbfgg-binder to use a temporary cloud environment (might take a minute or two!)\n",
     "<br><br><br><br><br><br>"
@@ -131,21 +131,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello there!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"hello there!\")"
    ]
@@ -184,21 +176,6 @@
     "\n",
     "- [binder](https://mybinder.org/), which cloud deploys GitHub Repos, associated with Project Jupyter\n",
     "- [colab](https://colab.research.google.com/notebooks/welcome.ipynb), which offers Jupyter Notebooks as \"Google Docs\", by Google"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
-    }
-   },
-   "source": [
-    "```\n",
-    "conda create -n jpnbfgg python=3.6\n",
-    "conda install jupyter matplotlib seaborn ipywidgets\n",
-    "conda install -c damianavila rise\n",
-    "```"
    ]
   }
  ],

--- a/JupyterNotebookForGreatGood/presentation.ipynb
+++ b/JupyterNotebookForGreatGood/presentation.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "If you'd like to follow along, either\n",
+    "\n",
+    "1) head to the GitHub repo for this talk, http://bit.ly/DSW2018-jpnbfgg-github, and follow the installation instructions\n",
+    "\n",
+    "2) go to this link http://bit.ly/DSW2018-jpnbfgg-binder to use a temporary cloud environment (might take a minute or two!)\n",
+    "<br><br><br><br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Use You Jupyter Notebook For Great Good"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## What is Jupyter Notebook?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Jupyter Notebooks are computational documents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "They allow the seamless integration of text and media with the computational output of just about any programming language."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "HTML, CSS, and JavaScript are the *linguae francae*, and the browser speaks them. No direct dependence on OS.\n",
+    "<br><br><br><br><br><br><br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Where did Jupyter Notebook Come From?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Created by [Project Jupyter](http://jupyter.org), centered here at [Berkeley's Institute for Data Science](https://bids.berkeley.edu/research/project-jupyter). The project is open source, so [anyone can (and should!) contribute](https://github.com/jupyter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## What are Jupyter Notebooks Used For?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "- Polished notebooks can be used for communication: results, best practices, education.\n",
+    "  - Check out this gallery for examples: https://github.com/jupyter/jupyter/wiki/A-gallery-of-interesting-Jupyter-Notebooks\n",
+    "- Notebooks are great for rapid iteration and prototyping of data analysis, especially if the workflow is highly visual."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "You can do just about anything with Jupyter Notebooks if you look around for the right tools/extensions. Even this presentation is a Jupyter Notebook!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello there!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hello there!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Let's get our hands dirty!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Clouds of Jupyter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "There are (at least) two services that offer free, small-to-mid-scale computation in the cloud via Jupyter Notebooks.\n",
+    "\n",
+    "- [binder](https://mybinder.org/), which cloud deploys GitHub Repos, associated with Project Jupyter\n",
+    "- [colab](https://colab.research.google.com/notebooks/welcome.ipynb), which offers Jupyter Notebooks as \"Google Docs\", by Google"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "source": [
+    "```\n",
+    "conda create -n jpnbfgg python=3.6\n",
+    "conda install jupyter matplotlib seaborn ipywidgets\n",
+    "conda install -c damianavila rise\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/JupyterNotebookForGreatGood/res/data/.gitignore
+++ b/JupyterNotebookForGreatGood/res/data/.gitignore
@@ -1,0 +1,3 @@
+# ignore this directory's contents except this file
+*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Here are some of the materials used in the pre-workshop tutorials for the GDSO D
 * July 9: [SQL and pandas](sql-pandas)
 * July 10: [Git and Python environment troubleshooting](git) 
 * July 11: [Matplotlib](matplotlib)
+* July 12: [Use You Jupyter Notebook For Great Good](JupyterNotebookForGreatGood)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: jpnbfgg
+channels:
+        - damianavila82
+dependencies:
+        - python=3.6
+        - matplotlib
+        - jupyter
+        - seaborn
+        - pandas
+        - ipywidgets
+        - rise


### PR DESCRIPTION
This PR will add the tutorial material on Jupyter notebooks in a top-level folder called `JupyterNotebookForGreatGood`, along with a link in the `README`.

Additionally, it adds an `environment.yml` file to the root directory. This file is used by [mybinder](https://mybinder.readthedocs.io/en/latest/), a service that turns GitHub repos into Jupyter instances on Docker images, letting folks run code inside a notebook on the cloud, meaning they don't have to modify their local computational environments.

As an added bonus, this will also work with the `matplotlib` tutorial.

The requirements in the `yml` are standard scientific python, save two: `ipywidgets`, an add-on to IPython that enables interactivity, and `RISE`, which converts notebooks into slide shows in Javascript. The latter is from a user Anaconda channel. See [the GitHub repo](https://github.com/damianavila/RISE) for details.